### PR TITLE
Add write-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ For parsing the above sample, in a file named `application.properties`
 (read-config "/Users/BG/file.does.not.exist") ;; => Raises FileNotFoundException
 
 (read-config "/Users/BG/file.does.not.exist" :default {}) ;; => {}
+
+
+;;; Converting a nested Clojure map to Java properties format
+(write-config {:foo "bar" :baz {:quux 42}})
+;;; => "baz.quux = 42\nfoo = bar"
 ```
 
 ## License

--- a/src/msync/properties/core.clj
+++ b/src/msync/properties/core.clj
@@ -32,7 +32,7 @@
   (reduce-kv (fn [r k v] (if (map? v)
                           (let [k1 (name k)]
                             (concat (map (fn [[k2 v2]] [(str k1 "." (name k2)) v2])
-                                         (write-config* [] v))
+                                         (dump-config v))
                                     r))
                           (conj r [(name k) v])))
              []

--- a/src/msync/properties/core.clj
+++ b/src/msync/properties/core.clj
@@ -1,7 +1,7 @@
 (ns msync.properties.core
   (:import java.util.Properties
            java.io.FileNotFoundException)
-  (:require [clojure.string :refer [split]]
+  (:require [clojure.string :refer [split join]]
             [clojure.java.io :refer [reader]]))
 
 ;;; Util
@@ -25,6 +25,20 @@
           {} (keys props)))
 
 
+(defn- dump-config
+  "Dump a config map to a sequence of key-value pairs collapsing
+   all nested keys if any."
+  [props]
+  (reduce-kv (fn [r k v] (if (map? v)
+                          (let [k1 (name k)]
+                            (concat (map (fn [[k2 v2]] [(str k1 "." (name k2)) v2])
+                                         (write-config* [] v))
+                                    r))
+                          (conj r [(name k) v])))
+             []
+             props))
+
+
 ;;; API
 (defn read-config
   "Read a Java properties file into a map."
@@ -35,3 +49,12 @@
          (fold-props props keyfn))
        (catch FileNotFoundException e
          (or default (throw e))))))
+
+
+(defn write-config
+  "Dump a (nested) property map to Java properties format."
+  [props]
+  (->> (dump-config props)
+       (sort-by first)
+       (map (fn [[k v]] (str k " = " v)))
+       (join "\n")))


### PR DESCRIPTION
```
Add new function `write-config` that converts a (nested) Clojure map to
Java properties format.

Example -
    (write-config {:foo "bar" :baz {:quux 42}})
    ;;; => "baz.quux = 42\nfoo = bar"
```
